### PR TITLE
GaussianCriterion.lua bug from common VAE source

### DIFF
--- a/modules/GaussianCriterion.lua
+++ b/modules/GaussianCriterion.lua
@@ -12,6 +12,7 @@ function GaussianCriterion:updateOutput(input, target)
    --Gelement:add(-1,torch.add(target,-1,input[1]):pow(2):cdiv(torch.exp(input[2])):mul(0.5))
    --self.output = torch.sum(Gelement)
 
+
    -- Reusing memory buffers
    self._Gelement = self._Gelement or input[2].new()
    self._Gelement:resizeAs(input[2]):copy(input[2])
@@ -34,10 +35,10 @@ function GaussianCriterion:updateOutput(input, target)
 end
 
 function GaussianCriterion:updateGradInput(input, target)
-   -- Verify again for correct handling of 0.5 multiplication
-   --self._gradInput[1] = torch.exp(-input[2]):cmul(torch.add(target,-1,input[1]))
-   --self._gradInput[2] = torch.exp(-input[2]):cmul(torch.add(target,-1,input[1]):pow(2)):add(-0.5)
 
+   --self._gradInput[1] = torch.exp(-input[2]):cmul(torch.add(target,-1,input[1]))
+   --self._gradInput[2] = torch.exp(-input[2]):mul(.5):cmul(torch.add(target,-1,input[1]):pow(2)):add(-0.5) 
+	
    -- Reusing memory buffers.
 	self._gradInput = self._gradInput or {}
    self._gradInput[1] = self._gradInput[1] or input[2].new()
@@ -46,7 +47,7 @@ function GaussianCriterion:updateGradInput(input, target)
    self._gradInput[1]:cmul(self._TI1)
    
    self._gradInput[2] = self._gradInput[2] or input[2].new()
-   self._gradInput[2]:resizeAs(input[2]):copy(input[2]):mul(-1):exp()
+   self._gradInput[2]:resizeAs(input[2]):copy(input[2]):mul(-1):exp():mul(.5)
    self._TI1:pow(2)
    self._gradInput[2]:cmul(self._TI1):add(-0.5)
 


### PR DESCRIPTION
There is a mistake in the gradient formula that has been fixed in the meantime in the original. I derived and tested it. It does not affect performance of dc-ign because GaussianCriterion.lua is not being used in any of the current autoencoders there.